### PR TITLE
Swift support and tests

### DIFF
--- a/OSCache/OSCache.m
+++ b/OSCache/OSCache.m
@@ -85,7 +85,7 @@
     NSLock *_lock;
 }
 
-- (id)init
+- (instancetype)init
 {
     if ((self = [super init]))
     {
@@ -394,9 +394,9 @@
 
 @implementation OSCache
 
-+ (id)alloc
++ (instancetype)allocWithZone:(struct _NSZone *)zone
 {
-    return (OSCache *)[OSCache_Private alloc];
+    return (OSCache *)[OSCache_Private allocWithZone:zone];
 }
 
 - (id)objectForKeyedSubscript:(__unused id<NSCopying>)key { return nil; }

--- a/Tests/OSCacheTests.xcodeproj/project.pbxproj
+++ b/Tests/OSCacheTests.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		01D28C8B1907BFC80021C719 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01D28C731907BFC80021C719 /* UIKit.framework */; };
 		01D28C951907BFC80021C719 /* OSCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01D28C941907BFC80021C719 /* OSCacheTests.m */; };
 		01D28CB01907C19E0021C719 /* OSCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 01D28CAE1907BFEC0021C719 /* OSCache.m */; };
+		FC63AE0F1C3DA85B00179DBC /* OSCacheTestsSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC63AE0E1C3DA85B00179DBC /* OSCacheTestsSwift.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +25,9 @@
 		01D28C941907BFC80021C719 /* OSCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OSCacheTests.m; sourceTree = "<group>"; };
 		01D28CAD1907BFEC0021C719 /* OSCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSCache.h; sourceTree = "<group>"; };
 		01D28CAE1907BFEC0021C719 /* OSCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSCache.m; sourceTree = "<group>"; };
+		FC63AE0D1C3DA85A00179DBC /* OSCacheTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OSCacheTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		FC63AE0E1C3DA85B00179DBC /* OSCacheTestsSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OSCacheTestsSwift.swift; sourceTree = "<group>"; };
+		FC63AE101C3DAE1400179DBC /* OSCache_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSCache_Private.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,8 +78,11 @@
 		01D28C8E1907BFC80021C719 /* OSCacheTests */ = {
 			isa = PBXGroup;
 			children = (
+				FC63AE101C3DAE1400179DBC /* OSCache_Private.h */,
 				01D28C941907BFC80021C719 /* OSCacheTests.m */,
+				FC63AE0E1C3DA85B00179DBC /* OSCacheTestsSwift.swift */,
 				01D28C8F1907BFC80021C719 /* Supporting Files */,
+				FC63AE0D1C3DA85A00179DBC /* OSCacheTests-Bridging-Header.h */,
 			);
 			path = OSCacheTests;
 			sourceTree = "<group>";
@@ -124,6 +131,7 @@
 		01D28C641907BFC80021C719 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Charcoal Design";
 				TargetAttributes = {
@@ -132,7 +140,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 01D28C671907BFC80021C719 /* Build configuration list for PBXProject "oscachetests" */;
+			buildConfigurationList = 01D28C671907BFC80021C719 /* Build configuration list for PBXProject "OSCacheTests" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -166,6 +174,7 @@
 			files = (
 				01D28CB01907C19E0021C719 /* OSCache.m in Sources */,
 				01D28C951907BFC80021C719 /* OSCacheTests.m in Sources */,
+				FC63AE0F1C3DA85B00179DBC /* OSCacheTestsSwift.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -341,8 +350,11 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "OSCacheTests/OSCacheTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = OSCacheTests;
+				SWIFT_OBJC_BRIDGING_HEADER = "OSCacheTests/OSCacheTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -358,8 +370,10 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				INFOPLIST_FILE = "OSCacheTests/OSCacheTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/Frameworks @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.charcoaldesign.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = OSCacheTests;
+				SWIFT_OBJC_BRIDGING_HEADER = "OSCacheTests/OSCacheTests-Bridging-Header.h";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -368,7 +382,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		01D28C671907BFC80021C719 /* Build configuration list for PBXProject "oscachetests" */ = {
+		01D28C671907BFC80021C719 /* Build configuration list for PBXProject "OSCacheTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				01D28C961907BFC80021C719 /* Debug */,

--- a/Tests/OSCacheTests/OSCacheTests-Bridging-Header.h
+++ b/Tests/OSCacheTests/OSCacheTests-Bridging-Header.h
@@ -1,0 +1,6 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "OSCache.h"
+#import "OSCache_Private.h"

--- a/Tests/OSCacheTests/OSCacheTests.m
+++ b/Tests/OSCacheTests/OSCacheTests.m
@@ -8,17 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "OSCache.h"
-
-
-@interface OSCache (Private)
-
-- (void)cleanUpAllObjects;
-- (void)resequence;
-- (NSDictionary *)cache;
-- (void)setSequenceNumber:(NSInteger)number;
-
-@end
-
+#import "OSCache_Private.h"
 
 @interface OSCacheTests : XCTestCase
 
@@ -31,6 +21,7 @@
 
 - (void)setUp
 {
+    [super setUp];
     self.cache = [[OSCache alloc] init];
     self.cache.countLimit = 3;
     self.cache.totalCostLimit = 100;
@@ -38,6 +29,7 @@
 
 - (void)tearDown
 {
+    [super tearDown];
     self.cache = nil;
 }
 

--- a/Tests/OSCacheTests/OSCacheTestsSwift.swift
+++ b/Tests/OSCacheTests/OSCacheTestsSwift.swift
@@ -1,0 +1,263 @@
+//
+//  OSCacheTestsSwift.swift
+//  OSCacheTests
+//
+//  Created by Tom King on 1/6/16.
+//  Copyright © 2016 IZI Mobile. All rights reserved.
+//
+
+import XCTest
+
+let TEST_COUNT = 2048
+
+class OSCacheTestsSwift: XCTestCase
+{
+    var cache: OSCache!
+    
+    override func setUp()
+    {
+        super.setUp()
+        cache = OSCache()
+        cache.countLimit = 3
+        cache.totalCostLimit = 100
+    }
+    
+    override func tearDown()
+    {
+        super.tearDown()
+        cache = nil
+    }
+    
+    func testInsertion()
+    {
+        cache.setObject(NSNumber(integer: 1), forKey: "foo", cost: 1)
+        cache.setObject(NSNumber(integer: 2), forKey: "bar", cost: 2)
+        cache.setObject(NSNumber(integer: 3), forKey: "baz", cost: 3)
+        
+        XCTAssertEqual(cache.count, 3, "Insertion failed")
+        XCTAssertEqual(cache.totalCost, 6, "Insertion failed")
+    }
+    
+    func testRemoval()
+    {
+        cache.setObject(NSNumber(integer: 1), forKey: "foo", cost: 1)
+        cache.setObject(NSNumber(integer: 2), forKey: "bar", cost: 2)
+        cache.setObject(NSNumber(integer: 3), forKey: "baz", cost: 3)
+        
+        cache.removeObjectForKey("bar")
+        
+        XCTAssertEqual(cache.count, 2, "Removal failed")
+        let bar = cache.objectForKey("bar")
+        XCTAssertNil(bar, "Removal failed")
+    }
+    
+    func testCountEviction()
+    {
+        cache.setObject(NSNumber(integer: 1), forKey: "foo")
+        cache.setObject(NSNumber(integer: 2), forKey: "bar")
+        cache.setObject(NSNumber(integer: 3), forKey: "baz")
+        cache.setObject(NSNumber(integer: 4), forKey: "bam")
+        
+        XCTAssertEqual(cache.count, 3, "Eviction failed")
+        let foo = cache.objectForKey("foo")
+        XCTAssertNil(foo, "Eviction failed")
+        
+        cache.setObject(NSNumber(integer: 4), forKey: "boo")
+        
+        XCTAssertEqual(cache.count, 3, "Eviction failed")
+        let bar = cache.objectForKey("bar")
+        XCTAssertNil(bar, "Eviction failed")
+    }
+    
+    func testCostEviction()
+    {
+        cache.setObject(NSNumber(integer: 1), forKey: "foo", cost: 99)
+        cache.setObject(NSNumber(integer: 2), forKey: "bar", cost: 2)
+        
+        XCTAssertEqual(cache.count, 1, "Eviction failed")
+        XCTAssertEqual(cache.totalCost, 2, "Eviction failed")
+        let foo = cache.objectForKey("foo")
+        XCTAssertNil(foo, "Eviction failed")
+        
+        cache.setObject(NSNumber(integer: 3), forKey: "baz", cost: 999)
+
+        XCTAssertEqual(cache.count, 0, "Eviction failed")
+        XCTAssertEqual(cache.totalCost, 0, "Eviction failed")
+    }
+    
+    func testCleanup()
+    {
+        cache.setObject(NSNumber(integer: 1), forKey: "foo")
+        cache.setObject(NSNumber(integer: 2), forKey: "bar")
+        cache.setObject(NSNumber(integer: 3), forKey: "baz")
+        
+        //simulate memory warning
+        cache.cleanUpAllObjects()
+        
+        XCTAssertEqual(cache.count, 0, "Cleanup failed")
+        XCTAssertEqual(cache.totalCost, 0, "Cleanup failed")
+    }
+    
+    func testResequence()
+    {
+        cache.setObject(NSNumber(integer: 1), forKey: "foo")
+        cache.setObject(NSNumber(integer: 2), forKey: "bar")
+        cache.setObject(NSNumber(integer: 3), forKey: "baz")
+        
+        cache.resequence()
+        
+        let innerCache = cache.cache()
+        XCTAssertEqual(innerCache["foo"]!.valueForKey("sequenceNumber") as? NSNumber, NSNumber(integer: 0), "Resequence failed")
+        XCTAssertEqual(innerCache["bar"]!.valueForKey("sequenceNumber") as? NSNumber, NSNumber(integer: 1), "Resequence failed")
+        XCTAssertEqual(innerCache["baz"]!.valueForKey("sequenceNumber") as? NSNumber, NSNumber(integer: 2), "Resequence failed")
+        
+        cache.removeObjectForKey("foo")
+        cache.resequence()
+        
+        XCTAssertEqual(innerCache["bar"]!.valueForKey("sequenceNumber") as? NSNumber, NSNumber(integer: 0), "Resequence failed")
+        XCTAssertEqual(innerCache["baz"]!.valueForKey("sequenceNumber") as? NSNumber, NSNumber(integer: 1), "Resequence failed")
+    }
+    
+    func testResequenceTrigger()
+    {
+        cache.setObject(NSNumber(integer: 1), forKey: "foo")
+        cache.setObject(NSNumber(integer: 2), forKey: "bar")
+        
+        //first object should now be bar with sequence number of 1
+        cache.removeObjectForKey("foo")
+        
+        //should trigger resequence
+        cache.setSequenceNumber(NSIntegerMax)
+        cache.setObject(NSNumber(integer: 3), forKey: "baz")
+        
+        let innerCache = cache.cache()
+        XCTAssertEqual(innerCache["bar"]!.valueForKey("sequenceNumber") as? NSNumber, NSNumber(integer: 0), "Resequence failed")
+        XCTAssertEqual(innerCache["baz"]!.valueForKey("sequenceNumber") as? NSNumber, NSNumber(integer: 1), "Resequence failed")
+        
+        //first object should now be baz with sequence number of 1
+        cache.removeObjectForKey("bar")
+        
+        //should also trigger resequence
+        cache.setSequenceNumber(NSIntegerMax)
+        cache.objectForKey("baz")
+        
+        XCTAssertEqual(innerCache["baz"]!.valueForKey("sequenceNumber") as? NSNumber, NSNumber(integer: 0), "Resequence failed")
+    }
+    
+    func testName()
+    {
+        cache.name = "Hello"
+        XCTAssertEqual(cache.name, "Hello", "Name failed")
+    }
+    
+    func testAccessPerf()
+    {
+        measureMetrics(OSCacheTestsSwift.defaultPerformanceMetrics(), automaticallyStartMeasuring: false) { () -> Void in
+            self.cache = OSCache()
+            self.cache.countLimit = TEST_COUNT
+            for i in 0..<TEST_COUNT
+            {
+                self.cache.setObject(NSNumber(integer: i), forKey: NSNumber(integer: i))
+            }
+            
+            self.startMeasuring()
+            
+            for i in 0..<TEST_COUNT
+            {
+                self.cache.objectForKey(NSNumber(integer: i))
+            }
+            
+            self.stopMeasuring()
+            
+            self.cache = nil
+        }
+    }
+    
+    func testInsertionPerf()
+    {
+        measureMetrics(OSCacheTestsSwift.defaultPerformanceMetrics(), automaticallyStartMeasuring: false) { () -> Void in
+            self.cache = OSCache()
+            self.cache.countLimit = TEST_COUNT
+            
+            self.startMeasuring()
+            
+            for i in 0..<TEST_COUNT
+            {
+                self.cache.setObject(NSNumber(integer: i), forKey: NSNumber(integer: i))
+            }
+            
+            self.stopMeasuring()
+            
+            self.cache = nil
+        }
+    }
+    
+    func testDeletionPerf()
+    {
+        measureMetrics(OSCacheTestsSwift.defaultPerformanceMetrics(), automaticallyStartMeasuring: false) { () -> Void in
+            self.cache = OSCache()
+            self.cache.countLimit = TEST_COUNT
+            for i in 0..<TEST_COUNT
+            {
+                self.cache.setObject(NSNumber(integer: i), forKey: NSNumber(integer: i))
+            }
+            
+            self.startMeasuring()
+            
+            for i in 0..<TEST_COUNT
+            {
+                self.cache.removeObjectForKey(NSNumber(integer: i))
+            }
+            
+            self.stopMeasuring()
+            
+            self.cache = nil
+        }
+    }
+    
+    func testOverflowInsertionsPerf()
+    {
+        measureMetrics(OSCacheTestsSwift.defaultPerformanceMetrics(), automaticallyStartMeasuring: false) { () -> Void in
+            self.cache = OSCache()
+            self.cache.countLimit = TEST_COUNT
+            for i in 0..<TEST_COUNT
+            {
+                self.cache.setObject(NSNumber(integer: i), forKey: NSNumber(integer: i))
+            }
+            
+            self.startMeasuring()
+            
+            for i in 0..<TEST_COUNT
+            {
+                self.cache.setObject(NSNumber(integer: i), forKey: NSNumber(integer: i + TEST_COUNT))
+            }
+            
+            self.stopMeasuring()
+            
+            self.cache = nil
+        }
+    }
+    
+    func testOverflowDeletionPerf()
+    {
+        measureMetrics(OSCacheTestsSwift.defaultPerformanceMetrics(), automaticallyStartMeasuring: false) { () -> Void in
+            self.cache = OSCache()
+            self.cache.countLimit = TEST_COUNT
+            for i in 0..<TEST_COUNT*2
+            {
+                self.cache.setObject(NSNumber(integer: i), forKey: NSNumber(integer: i))
+            }
+            
+            self.startMeasuring()
+            
+            for i in 0..<TEST_COUNT
+            {
+                self.cache.removeObjectForKey(NSNumber(integer: i))
+            }
+            
+            self.stopMeasuring()
+            
+            self.cache = nil
+        }
+    }
+}

--- a/Tests/OSCacheTests/OSCache_Private.h
+++ b/Tests/OSCacheTests/OSCache_Private.h
@@ -1,0 +1,21 @@
+//
+//  OSCache_Private.h
+//  OSCacheTests
+//
+//  Created by Tom King on 1/6/16.
+//  Copyright © 2016 IZI Mobile. All rights reserved.
+//
+
+#ifndef OSCache_Private_h
+#define OSCache_Private_h
+
+@interface OSCache (Private)
+
+- (void)cleanUpAllObjects;
+- (void)resequence;
+- (NSDictionary *)cache;
+- (void)setSequenceNumber:(NSInteger)number;
+
+@end
+
+#endif /* OSCache_Private_h */


### PR DESCRIPTION
This makes a change to properly support Swift - it seems that overriding `+ (id)alloc` in `OSCache` doesn't properly initialize an `OSCache` object in Swift, and causes the object to be an `NSCache`. Overriding `+ (instancetype)allocWithZone:(struct _NSZone *)zone` instead works as expected. Added Swift tests that are parallel to the current tests to verify this.
